### PR TITLE
Make the trend arrow size a smidge smaller

### DIFF
--- a/LoopCaregiver/LoopCaregiverWatchApp/HomeView.swift
+++ b/LoopCaregiver/LoopCaregiverWatchApp/HomeView.swift
@@ -42,7 +42,7 @@ struct HomeView: View {
                     Image(systemName: egv.arrowImageName())
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width:35.0)
+                        .frame(width:25.0)
                         .offset(.init(width: 0.0, height: 3.0))
                 }
                 //BG delta


### PR DESCRIPTION
* Adjust the trend arrow size in the Watch Home view from 35.0 down to 25.0
* It was previously too large, particularly for diagonal arrows